### PR TITLE
Adjusting the thresholds to reflect the new licenses number.

### DIFF
--- a/dashboards/1password-metrics.json
+++ b/dashboards/1password-metrics.json
@@ -416,7 +416,7 @@
           "defaults": {
             "displayName": "Active User Count",
             "mappings": [],
-            "max": 240,
+            "max": 280,
             "thresholds": {
               "mode": "absolute",
               "steps": [
@@ -426,11 +426,11 @@
                 },
                 {
                   "color": "orange",
-                  "value": 230
+                  "value": 265
                 },
                 {
                   "color": "red",
-                  "value": 235
+                  "value": 275
                 }
               ]
             }


### PR DESCRIPTION
A new set of 40 licenses were added to our 1Password, so I'm adjusting the thresholds with the new values.