### PR TITLE
use the correct enviroment name for platformservices

### DIFF
--- a/environments/platform/terragrunt.hcl
+++ b/environments/platform/terragrunt.hcl
@@ -10,5 +10,5 @@ include {
 }
 
 inputs = {
-  environment = "dfdsplatformservices"
+  environment = "platformservices"
 }


### PR DESCRIPTION
The name must be aligned with the name in https://github.com/dfds/grafana-cloud-environments/blob/main/environments/platform-services/terragrunt.hcl