### PR TITLE
Revert "use the correct enviroment name for platformservices"

### DIFF
--- a/environments/platform/terragrunt.hcl
+++ b/environments/platform/terragrunt.hcl
@@ -10,5 +10,5 @@ include {
 }
 
 inputs = {
-  environment = "platformservices"
+  environment = "dfdsplatformservices"
 }


### PR DESCRIPTION
Reverts dfds/grafana-cloud-objects#69, because of damn SSM :) 