### PR TITLE
use the datasource uid for cloudwatch on platform stack

### DIFF
--- a/alertrules/EC2 Worker Node Credit Balance alert.json
+++ b/alertrules/EC2 Worker Node Credit Balance alert.json
@@ -18,7 +18,7 @@
                                 "from": 300,
                                 "to": 0
                             },
-                            "datasourceUid": "fdey90cd04a2oa",
+                            "datasourceUid": "edp232mk1y58gc",
                             "model": {
                                 "alias": "",
                                 "dimensions": {


### PR DESCRIPTION
This is to fix an alert error:

`failed to build query 'A': data source not found`