### PR TITLE
Add athena data source

### DIFF
--- a/data_sources/aws_athena/athena-iam-roles-anywhere.json
+++ b/data_sources/aws_athena/athena-iam-roles-anywhere.json
@@ -1,0 +1,10 @@
+{
+  "name": "Athena-AWS-Backup",
+  "assumeRoleArn": "arn:aws:iam::303242044692:role/grafana-cloud-athena",
+  "authType": "grafana_assume_role",
+  "catalog": "iam-rolesanywhere-pca-observability",
+  "database": "iam_rolesanywhere_pca_observability",
+  "defaultRegion": "eu-central-1",
+  "outputLocation": "s3://dfds-iam-rolesanywhere-pca-observability-athena",
+  "workgroup": "iam-rolesanywhere-pca-observability"
+}

--- a/data_sources/aws_athena/athena-iam-roles-anywhere.json
+++ b/data_sources/aws_athena/athena-iam-roles-anywhere.json
@@ -1,5 +1,5 @@
 {
-  "name": "Athena-AWS-Backup",
+  "name": "Athena-IAM-roles-anywhere",
   "assumeRoleArn": "arn:aws:iam::303242044692:role/grafana-cloud-athena",
   "authType": "grafana_assume_role",
   "catalog": "iam-rolesanywhere-pca-observability",


### PR DESCRIPTION
Part of: https://github.com/dfds/cloudplatform/issues/2589
I want to switch to using grafana cloud for IAM roles anywhere observability so I need an athena data source in garfana cloud.