### PR TITLE
fix: update athena assumerolename

### DIFF
--- a/data_sources/aws_athena/athena-iam-roles-anywhere.json
+++ b/data_sources/aws_athena/athena-iam-roles-anywhere.json
@@ -1,6 +1,6 @@
 {
   "name": "Athena-IAM-roles-anywhere",
-  "assumeRoleArn": "arn:aws:iam::303242044692:role/grafana-cloud-athena",
+  "assumeRoleArn": "arn:aws:iam::303242044692:role/grafana-cloud-observability",
   "authType": "grafana_assume_role",
   "catalog": "iam-rolesanywhere-pca-observability",
   "database": "iam_rolesanywhere_pca_observability",


### PR DESCRIPTION
This PR updates the name of the Athena assumerole for IAM Roles Anywhere after it was changed