### PR TITLE
This enables us the option of enabling each module per environment using a toggle instead of deploying everything to all environments.

### DIFF
--- a/environments/demo/terragrunt.hcl
+++ b/environments/demo/terragrunt.hcl
@@ -11,4 +11,10 @@ include {
 
 inputs = {
   environment = "demo"
+  enable_ce_folder                     = true
+  enable_dashboards                    = true
+  enable_alerts                        = true
+  enable_grafana_data_source_aws_athena = true
+  enable_grafana_data_source_aws_cloudwatch = true
+  enable_grafana_notification          = true
 }

--- a/environments/platform/terragrunt.hcl
+++ b/environments/platform/terragrunt.hcl
@@ -10,5 +10,11 @@ include {
 }
 
 inputs = {
-  environment = "dfdsplatformservices"
+  environment                          = "dfdsplatformservices"
+  enable_ce_folder                     = true
+  enable_dashboards                    = true
+  enable_alerts                        = true
+  enable_grafana_data_source_aws_athena = true
+  enable_grafana_data_source_aws_cloudwatch = true
+  enable_grafana_notification          = true
 }

--- a/environments/sandbox/terragrunt.hcl
+++ b/environments/sandbox/terragrunt.hcl
@@ -10,5 +10,11 @@ include {
 }
 
 inputs = {
-  environment = "sandbox"
+  environment                          = "sandbox"
+  enable_ce_folder                     = true
+  enable_dashboards                    = true
+  enable_alerts                        = false
+  enable_grafana_data_source_aws_athena = true
+  enable_grafana_data_source_aws_cloudwatch = true
+  enable_grafana_notification          = false
 }

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,7 @@ locals {
   dashboard_data = [for f in local.dashboard_files : {
     filename = f
     content  = (file(f))
-    }
-  ]
+  }]
 
   alertrule_files             = fileset(path.module, "alertrules/*.json")
   data_sources_aws_athena     = fileset(path.module, "data_sources/aws_athena/*.json")
@@ -12,46 +11,52 @@ locals {
 }
 
 module "ce_folder" {
-  #checkov:skip=CKV_TF_1:We rely on release tags
+  count  = var.enable_ce_folder ? 1 : 0
   source = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_folder?ref=2.1.0"
   #source = "../../../../../../terraform-grafana-cloud//grafana_folder" # Support for local development
-  title = var.folder_title
+  #checkov:skip=CKV_TF_1:We rely on release tags
+  title  = var.folder_title
 }
 
 module "dashboards" {
+  count       = var.enable_dashboards && var.enable_ce_folder ? 1 : 0
+  source      = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_dashboard?ref=2.1.0"
+  #source = "../../../../../../terraform-grafana-cloud//grafana_dashboard" # Support for local development
   #checkov:skip=CKV_TF_1:We rely on release tags
-  source = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_dashboard?ref=2.1.0"
-  #source      = "../../../../../../terraform-grafana-cloud//grafana_dashboard" # Support for local development
-  folder      = module.ce_folder.id
+  folder      = module.ce_folder[0].id
   config_json = local.dashboard_data
 }
 
 module "alerts" {
+  count           = var.enable_alerts && var.enable_ce_folder ? 1 : 0
+  source          = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_alert?ref=2.1.0"
+  #source = "../../../../../../terraform-grafana-cloud//grafana_alert" # Support for local development
   #checkov:skip=CKV_TF_1:We rely on release tags
-  source = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_alert?ref=2.1.0"
-  # source          = "../../../../../../terraform-grafana-cloud//grafana_alert" # Support for local development
-  folder          = module.ce_folder.uid
+  folder          = module.ce_folder[0].uid
   alertrule_files = local.alertrule_files
 }
 
 module "grafana_data_source_aws_athena" {
+  count        = var.enable_grafana_data_source_aws_athena ? 1 : 0
+  source       = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_data_source_athena?ref=2.1.0"
+  #source = "../../../../../../terraform-grafana-cloud//grafana_data_source_athena" # Support for local development
   #checkov:skip=CKV_TF_1:We rely on release tags
-  source = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_data_source_athena?ref=2.1.0"
-  #source      = "../../../../../../terraform-grafana-cloud//grafana_data_source_athena" # Support for local development
   data_sources = local.data_sources_aws_athena
 }
 
 module "grafana_data_source_aws_cloudwatch" {
+  count        = var.enable_grafana_data_source_aws_cloudwatch ? 1 : 0
+  source       = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_data_source_cloudwatch?ref=2.1.0"
+  #source = "../../../../../../terraform-grafana-cloud//grafana_data_source_cloudwatch" # Support for local development
   #checkov:skip=CKV_TF_1:We rely on release tags
-  source = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_data_source_cloudwatch?ref=2.1.0"
-  #source       = "../../../../../../terraform-grafana-cloud//grafana_data_source_cloudwatch" # Support for local development
   data_sources = local.data_sources_aws_cloudwatch
 }
 
 module "grafana_notification" {
+  count                = var.enable_grafana_notification ? 1 : 0
+  source               = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_notification?ref=2.1.0"
+  #source = "../../../../../../terraform-grafana-cloud//grafana_notification" # Support for local development
   #checkov:skip=CKV_TF_1:We rely on release tags
-  source = "git::https://github.com/dfds/terraform-grafana-cloud.git//grafana_notification?ref=2.1.0"
-  #source               = "../../../../../../terraform-grafana-cloud//grafana_notification" # Support for local development
   notification_enabled = true
   name                 = "Cloud Engineering Slack"
   slack_webhook_url    = var.notification_slack_webhook_url
@@ -61,4 +66,34 @@ module "grafana_notification" {
     match = "="
     value = "Cloud Engineering"
   }]
+}
+
+moved {
+  from = module.ce_folder
+  to   = module.ce_folder[0]
+}
+
+moved {
+  from = module.dashboards
+  to   = module.dashboards[0]
+}
+
+moved {
+  from = module.alerts
+  to   = module.alerts[0]
+}
+
+moved {
+  from = module.grafana_data_source_aws_athena
+  to   = module.grafana_data_source_aws_athena[0] 
+}
+
+moved {
+  from = module.grafana_data_source_aws_cloudwatch
+  to   = module.grafana_data_source_aws_cloudwatch[0]
+}
+
+moved {
+  from = module.grafana_notification
+  to   = module.grafana_notification[0]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "dashboard_meta" {
-  value = module.dashboards.meta
+  value = var.enable_dashboards && var.enable_ce_folder ? module.dashboards[0].meta : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,39 @@ variable "notification_slack_webhook_url" {
   description = "Slack webhook URL."
   sensitive   = true
 }
+
+variable "enable_ce_folder" {
+  type        = bool
+  default     = true
+  description = "Enable the CE Folder module."
+}
+
+variable "enable_dashboards" {
+  type        = bool
+  default     = true
+  description = "Enable the Dashboards module."
+}
+
+variable "enable_alerts" {
+  type        = bool
+  default     = true
+  description = "Enable the Alerts module."
+}
+
+variable "enable_grafana_data_source_aws_athena" {
+  type        = bool
+  default     = true
+  description = "Enable the Grafana AWS Athena Data Source module."
+}
+
+variable "enable_grafana_data_source_aws_cloudwatch" {
+  type        = bool
+  default     = true
+  description = "Enable the Grafana AWS CloudWatch Data Source module."
+}
+
+variable "enable_grafana_notification" {
+  type        = bool
+  default     = true
+  description = "Enable the Grafana Notification module."
+}

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 5.34.0"
     }
     grafana = {


### PR DESCRIPTION
As per issue #2883 this should solve that problem.
Have tested this and it should be good.
After refactoring terraform would find 'new' resources and had to destroy and recreate new ones. Therefor used the moved function of terraform and now it'll just rename them in the State file rather than destroy/recreate.