### PR TITLE
Some Kubernetes dashboards missing from/not migrated to Grafana Cloud #2937

### DIFF
--- a/dashboards/k8s-resources-cluster.json
+++ b/dashboards/k8s-resources-cluster.json
@@ -147,7 +147,7 @@
                   "type": "prometheus",
                   "uid": "${datasource}"
                },
-               "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"node-exporter\",cluster=\"$cluster\"})",
+               "expr": "1 - sum(:node_memory_MemAvailable_bytes:sum{cluster=\"$cluster\"}) / sum(node_memory_MemTotal_bytes{job=\"integrations/node_exporter\",cluster=\"$cluster\"})",
                "instant": true
             }
          ],

--- a/prometheus_rules/kubernetes_mixin_rules.yaml
+++ b/prometheus_rules/kubernetes_mixin_rules.yaml
@@ -663,26 +663,26 @@ groups:
         record: "node_namespace_pod:kube_pod_info:"
       - expr: |
           count by (cluster, node) (
-            node_cpu_seconds_total{mode="idle",job="node-exporter"}
+            node_cpu_seconds_total{mode="idle",job="integrations/node_exporter"}
             * on (cluster, namespace, pod) group_left(node)
             topk by(cluster, namespace, pod) (1, node_namespace_pod:kube_pod_info:)
           )
         record: "node:node_num_cpu:sum"
       - expr: |
           sum(
-            node_memory_MemAvailable_bytes{job="node-exporter"} or
+            node_memory_MemAvailable_bytes{job="integrations/node_exporter"} or
             (
-              node_memory_Buffers_bytes{job="node-exporter"} +
-              node_memory_Cached_bytes{job="node-exporter"} +
-              node_memory_MemFree_bytes{job="node-exporter"} +
-              node_memory_Slab_bytes{job="node-exporter"}
+              node_memory_Buffers_bytes{job="integrations/node_exporter"} +
+              node_memory_Cached_bytes{job="integrations/node_exporter"} +
+              node_memory_MemFree_bytes{job="integrations/node_exporter"} +
+              node_memory_Slab_bytes{job="integrations/node_exporter"}
             )
           ) by (cluster)
         record: ":node_memory_MemAvailable_bytes:sum"
       - expr: |
           avg by (cluster, node) (
             sum without (mode) (
-              rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",job="node-exporter"}[5m])
+              rate(node_cpu_seconds_total{mode!="idle",mode!="iowait",mode!="steal",job="integrations/node_exporter"}[5m])
             )
           )
         record: "node:node_cpu_utilization:ratio_rate5m"


### PR DESCRIPTION
- Removed dashboards that we didn't use in self-hosted grafana:
-- Scheduler
-- Proxy

- Replaced API Server Dashboard with a useful one!


