### PR TITLE
use job name instead of namespace to filter query results for alert conditions

### DIFF
--- a/alertrules/Blackbox probe target is down.json
+++ b/alertrules/Blackbox probe target is down.json
@@ -22,7 +22,7 @@
               "model": {
                 "editorMode": "code",
                 "exemplar": true,
-                "expr": "probe_success{namespace!=\"platform-secrets-manag-yjeap\"}",
+                "expr": "probe_success{job!=\"prometheus-blackbox-exporter\"}",
                 "instant": true,
                 "interval": "",
                 "intervalMs": 1000,


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request includes a change to the alert rule configuration for the Blackbox probe target. The most significant change is the modification of the expression used to filter the probe success metric.

Changes to alert rule configuration:

* [`alertrules/Blackbox probe target is down.json`](diffhunk://#diff-93187c1b1b9ff05c2e6bd31ee41411a0f73477e8a6af2d4ab79bbdd94fe8f204L25-R25): Updated the `expr` field to filter out the `prometheus-blackbox-exporter` job instead of the `platform-secrets-manag-yjeap` namespace.
## Issue ticket number and link
<!--#issue number here -->

## Checklist before requesting a review
- [ ] I have rebased or merged in the latest from the default branch.
- [ ] I have tested changes locally in a Docker image.
