### PR TITLE
fix wrong label condition on blackbox probe

### DIFF
--- a/alertrules/Blackbox probe target is down.json
+++ b/alertrules/Blackbox probe target is down.json
@@ -22,7 +22,7 @@
               "model": {
                 "editorMode": "code",
                 "exemplar": true,
-                "expr": "probe_success{job!=\"prometheus-blackbox-exporter\"}",
+                "expr": "probe_success{job=\"prometheus-blackbox-exporter\"}",
                 "instant": true,
                 "interval": "",
                 "intervalMs": 1000,


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request includes a change to the alert rule for the Blackbox probe target. The change corrects the expression used to filter the `probe_success` metric.

* [`alertrules/Blackbox probe target is down.json`](diffhunk://#diff-93187c1b1b9ff05c2e6bd31ee41411a0f73477e8a6af2d4ab79bbdd94fe8f204L25-R25): Corrected the `expr` field to properly filter for the `prometheus-blackbox-exporter` job.
## Issue ticket number and link
<!--#issue number here -->
https://dev.azure.com/dfds/Cloud%20Engineering%20Team/_workitems/edit/520827
## Checklist before requesting a review
- [x] I have rebased or merged in the latest from the default branch.
- [ ] I have tested changes locally in a Docker image.
