### PR TITLE
fix blackbox probe target again

### DIFF
--- a/alertrules/Blackbox probe target is down.json
+++ b/alertrules/Blackbox probe target is down.json
@@ -47,7 +47,7 @@
                         1,
                         0
                       ],
-                      "type": "lt"
+                      "type": "ne"
                     },
                     "operator": {
                       "type": "and"


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request includes a small but important change to the alert rule configuration in the `alertrules/Blackbox probe target is down.json` file. The change modifies the comparison type for the alert condition.

Alert rule configuration update:

* [`alertrules/Blackbox probe target is down.json`](diffhunk://#diff-93187c1b1b9ff05c2e6bd31ee41411a0f73477e8a6af2d4ab79bbdd94fe8f204L50-R50): Changed the comparison type from "lt" (less than) to "ne" (not equal) to adjust the alert condition.
## Issue ticket number and link
<!--#issue number here -->
https://dev.azure.com/dfds/Cloud%20Engineering%20Team/_workitems/edit/520827
## Checklist before requesting a review
- [x] I have rebased or merged in the latest from the default branch.
- [ ] I have tested changes locally in a Docker image.
