### PR TITLE
fix to fix blackbox prob alert

### DIFF
--- a/alertrules/Blackbox probe target is down.json
+++ b/alertrules/Blackbox probe target is down.json
@@ -33,6 +33,49 @@
               }
             },
             {
+              "refId": "C",
+              "relativeTimeRange": {
+                "from": 0,
+                "to": 0
+              },
+              "datasourceUid": "__expr__",
+              "model": {
+                "conditions": [
+                  {
+                    "evaluator": {
+                      "params": [
+                        0,
+                        0
+                      ],
+                      "type": "gt"
+                    },
+                    "operator": {
+                      "type": "and"
+                    },
+                    "query": {
+                      "params": []
+                    },
+                    "reducer": {
+                      "params": [],
+                      "type": "avg"
+                    },
+                    "type": "query"
+                  }
+                ],
+                "datasource": {
+                  "name": "Expression",
+                  "type": "__expr__",
+                  "uid": "__expr__"
+                },
+                "expression": "A",
+                "intervalMs": 1000,
+                "maxDataPoints": 43200,
+                "reducer": "last",
+                "refId": "C",
+                "type": "reduce"
+              }
+            },
+            {
               "refId": "B",
               "relativeTimeRange": {
                 "from": 0,
@@ -47,7 +90,7 @@
                         1,
                         0
                       ],
-                      "type": "ne"
+                      "type": "lt"
                     },
                     "operator": {
                       "type": "and"


### PR DESCRIPTION
## Describe your changes
This pull request includes changes to the alert rules configuration in the `alertrules/Blackbox probe target is down.json` file. The most important changes involve adding a new query and modifying an existing condition type.

Changes to alert rules configuration:

* Added a new query with `refId` "C" to the alert rules configuration, which includes conditions, datasource information, and expression details.
* Modified the condition type from "ne" (not equal) to "lt" (less than) for an existing query in the alert rules configuration.

## Issue ticket number and link
https://dev.azure.com/dfds/Cloud%20Engineering%20Team/_workitems/edit/520827

## Checklist before requesting a review
- [ ] I have rebased or merged in the latest from the default branch.
- [ ] I have tested changes locally in a Docker image.
