### PR TITLE
fix blackbox probe again

### DIFF
--- a/alertrules/Blackbox probe target is down.json
+++ b/alertrules/Blackbox probe target is down.json
@@ -5,7 +5,7 @@
       "orgId": 1,
       "name": "Blackbox probe target is down",
       "folder": "Cloud Engineering",
-      "interval": "1m",
+      "interval": "5m",
       "rules": [
         {
           "uid": "cdp232nznumf5e",
@@ -22,7 +22,7 @@
               "model": {
                 "editorMode": "code",
                 "exemplar": true,
-                "expr": "probe_success{job=\"prometheus-blackbox-exporter\"}",
+                "expr": "count(probe_success{job=\"prometheus-blackbox-exporter\"})-sum(probe_success{job=\"prometheus-blackbox-exporter\"})",
                 "instant": true,
                 "interval": "",
                 "intervalMs": 1000,
@@ -33,7 +33,7 @@
               }
             },
             {
-              "refId": "C",
+              "refId": "B",
               "relativeTimeRange": {
                 "from": 0,
                 "to": 0
@@ -70,48 +70,6 @@
                 "expression": "A",
                 "intervalMs": 1000,
                 "maxDataPoints": 43200,
-                "reducer": "last",
-                "refId": "C",
-                "type": "reduce"
-              }
-            },
-            {
-              "refId": "B",
-              "relativeTimeRange": {
-                "from": 0,
-                "to": 0
-              },
-              "datasourceUid": "__expr__",
-              "model": {
-                "conditions": [
-                  {
-                    "evaluator": {
-                      "params": [
-                        1,
-                        0
-                      ],
-                      "type": "lt"
-                    },
-                    "operator": {
-                      "type": "and"
-                    },
-                    "query": {
-                      "params": []
-                    },
-                    "reducer": {
-                      "params": [],
-                      "type": "avg"
-                    },
-                    "type": "query"
-                  }
-                ],
-                "datasource": {
-                  "name": "Expression",
-                  "type": "__expr__",
-                  "uid": "__expr__"
-                },
-                "expression": "A",
-                "hide": false,
                 "refId": "B",
                 "type": "threshold"
               }
@@ -121,7 +79,7 @@
           "panelId": 190,
           "noDataState": "Alerting",
           "execErrState": "Alerting",
-          "for": "1m",
+          "for": "5m",
           "annotations": {
             "__alertId__": "176",
             "__dashboardUid__": "bXDq_ZNnz",


### PR DESCRIPTION
## Describe your changes
<!--Describe the change here-->
This pull request includes several changes to the `alertrules/Blackbox probe target is down.json` file to adjust the alerting configuration and improve the accuracy of the alert conditions.

Key changes:

* **Alert Interval Adjustment:**
  * Changed the alert evaluation interval from 1 minute to 5 minutes.
  * Updated the alert condition duration from 1 minute to 5 minutes.

* **Expression Modification:**
  * Modified the expression to calculate the difference between the count and sum of `probe_success` for the `prometheus-blackbox-exporter` job.

* **RefId Updates:**
  * Changed the `refId` from "C" to "B" in the alert rule configuration.

* **Alert Rule Simplification:**
  * Removed redundant conditions and simplified the alert rule structure by eliminating unnecessary configurations.
## Issue ticket number and link
<!--#issue number here -->
https://dev.azure.com/dfds/Cloud%20Engineering%20Team/_workitems/edit/520827

## Checklist before requesting a review
- [ ] I have rebased or merged in the latest from the default branch.
- [ ] I have tested changes locally in a Docker image.
