### PR TITLE
Updates to distinct and date based query.

### DIFF
--- a/dashboards/aws-backup-metrics.json
+++ b/dashboards/aws-backup-metrics.json
@@ -1,550 +1,548 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": {
-            "type": "grafana",
-            "uid": "-- Grafana --"
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "fiscalYearStartMonth": 0,
-    "graphTooltip": 0,
-    "id": 203,
-    "links": [],
-    "panels": [
+  "annotations": {
+    "list": [
       {
+        "builtIn": 1,
         "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
+          "type": "grafana",
+          "uid": "-- Grafana --"
         },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 0
-        },
-        "id": 1,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "text": {
-            "valueSize": 100
-          },
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT COUNT(account_id) FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" where \"job_status\" = 'COMPLETED'; ",
-            "refId": "A"
-          }
-        ],
-        "title": "Completed Backup Jobs",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 0
-        },
-        "id": 3,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT COUNT(account_id) FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" where \"resource_type\" = 'RDS'; ",
-            "refId": "A"
-          }
-        ],
-        "title": "RDS Instances",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                },
-                {
-                  "color": "red",
-                  "value": 0
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 8
-        },
-        "id": 2,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT COUNT(account_id) FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" where \"job_status\" = 'FAILED'; ",
-            "refId": "A"
-          }
-        ],
-        "title": "Failed Backup Jobs",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 8
-        },
-        "id": 4,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT COUNT(account_id) FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" where \"resource_type\" != 'RDS'; ",
-            "refId": "A"
-          }
-        ],
-        "title": "DynamoDB Instances",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "text",
-                  "value": null
-                }
-              ]
-            },
-            "unit": "dthms"
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 0,
-          "y": 16
-        },
-        "id": 5,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "/^average_run_time_in_seconds$/",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT AVG(\n  CAST(SUBSTRING(job_run_time, 1, 2) AS INT) * 3600 +\n  CAST(SUBSTRING(job_run_time, 4, 2) AS INT) * 60 +\n  CAST(SUBSTRING(job_run_time, 7, 2) AS INT)     \n) AS average_run_time_in_seconds\nFROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" WHERE job_run_time <> '';",
-            "refId": "A"
-          }
-        ],
-        "title": "Average Run Time",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "green",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 16
-        },
-        "id": 6,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT\n  COUNT(*) AS number_of_prod_arns\nFROM\n  \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\"\nWHERE\n  resource_arn LIKE '\"%prod%\"'; ",
-            "refId": "A"
-          }
-        ],
-        "title": "Number of PROD Instances",
-        "transparent": true,
-        "type": "stat"
-      },
-      {
-        "datasource": {
-          "type": "grafana-athena-datasource",
-          "uid": "${datasource}"
-        },
-        "fieldConfig": {
-          "defaults": {
-            "color": {
-              "mode": "thresholds"
-            },
-            "mappings": [],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                {
-                  "color": "dark-purple",
-                  "value": null
-                }
-              ]
-            }
-          },
-          "overrides": []
-        },
-        "gridPos": {
-          "h": 8,
-          "w": 12,
-          "x": 12,
-          "y": 24
-        },
-        "id": 7,
-        "options": {
-          "colorMode": "value",
-          "graphMode": "area",
-          "justifyMode": "auto",
-          "orientation": "auto",
-          "reduceOptions": {
-            "calcs": [
-              "lastNotNull"
-            ],
-            "fields": "",
-            "values": false
-          },
-          "showPercentChange": false,
-          "textMode": "auto",
-          "wideLayout": true
-        },
-        "pluginVersion": "11.1.0-68838",
-        "targets": [
-          {
-            "connectionArgs": {
-              "catalog": "__default",
-              "database": "__default",
-              "region": "__default",
-              "resultReuseEnabled": false,
-              "resultReuseMaxAgeInMinutes": 60
-            },
-            "datasource": {
-              "type": "grafana-athena-datasource",
-              "uid": "${datasource}"
-            },
-            "format": 1,
-            "rawSQL": "SELECT\n  COUNT(*) AS number_of_prod_arns\nFROM\n  \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\"\nWHERE\n  resource_arn NOT LIKE '\"%prod%\"'; ",
-            "refId": "A"
-          }
-        ],
-        "title": "Number of NON PROD Instances",
-        "transparent": true,
-        "type": "stat"
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "schemaVersion": 39,
-    "tags": [],
-    "templating": {
-      "list": [
-        {
-          "current": {
-            "selected": false,
-            "text": "Athena-AWS-Backup",
-            "value": "athena-grafana-aws-backup"
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 42,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
           },
-          "hide": 0,
-          "includeAll": false,
-          "multi": false,
-          "name": "datasource",
-          "options": [],
-          "query": "grafana-athena-datasource",
-          "refresh": 1,
-          "regex": "",
-          "skipUrlSync": false,
-          "type": "datasource"
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "text": {
+          "valueSize": 100
+        },
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT COUNT(account_id) FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" where \"job_status\" = 'COMPLETED' AND substr(TRIM(\"report_time_period_end\"), 1, 10) = CAST(CURRENT_DATE AS VARCHAR); ",
+          "refId": "A"
         }
-      ]
+      ],
+      "title": "Completed Backup Jobs",
+      "transparent": true,
+      "type": "stat"
     },
-    "time": {
-      "from": "now-24h",
-      "to": "now"
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "column": "account_id",
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT COUNT(resource_arn) AS resource_count FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" WHERE \"resource_type\" = 'RDS' AND substr(\"report_time_period_end\", 1, 10) = CAST(CURRENT_DATE AS VARCHAR);",
+          "refId": "A",
+          "table": "aws-backup-dashboards_service_metrics"
+        }
+      ],
+      "title": "RDS Instances",
+      "transparent": true,
+      "type": "stat"
     },
-    "timeRangeUpdatedDuringEditOrView": false,
-    "timepicker": {},
-    "timezone": "browser",
-    "title": "AWS Backup Metrics",
-    "uid": "aws_backup_metrics",
-    "version": 3,
-    "weekStart": ""
-  }
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT COUNT(DISTINCT account_id) \nFROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" \nWHERE \"job_status\" = 'FAILED';",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Backup Jobs",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT COUNT(resource_arn) AS resource_arn FROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" WHERE \"resource_type\" NOT IN ('RDS', 'EFS') AND substr(TRIM(\"report_time_period_end\"), 1, 10) = CAST(CURRENT_DATE AS VARCHAR); ",
+          "refId": "A"
+        }
+      ],
+      "title": "DynamoDB Instances",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text"
+              }
+            ]
+          },
+          "unit": "dthms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "/^average_run_time_in_seconds$/",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT AVG(\n  CAST(SUBSTRING(job_run_time, 1, 2) AS INT) * 3600 +\n  CAST(SUBSTRING(job_run_time, 4, 2) AS INT) * 60 +\n  CAST(SUBSTRING(job_run_time, 7, 2) AS INT)     \n) AS average_run_time_in_seconds\nFROM \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\" WHERE job_run_time <> ''\nAND substr(TRIM(\"report_time_period_end\"), 1, 10) = CAST(CURRENT_DATE AS VARCHAR);",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Run Time",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT\n  COUNT(*) AS number_of_prod_arns\nFROM\n  \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\"\nWHERE\n  resource_arn LIKE '\"%prod%\"'\nAND substr(TRIM(\"report_time_period_end\"), 1, 10) = CAST(CURRENT_DATE AS VARCHAR);\n",
+          "refId": "A"
+        }
+      ],
+      "title": "Number of PROD Instances",
+      "transparent": true,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "grafana-athena-datasource",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "dark-purple"
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0-84846",
+      "targets": [
+        {
+          "connectionArgs": {
+            "catalog": "__default",
+            "database": "__default",
+            "region": "__default",
+            "resultReuseEnabled": false,
+            "resultReuseMaxAgeInMinutes": 60
+          },
+          "datasource": {
+            "type": "grafana-athena-datasource",
+            "uid": "${datasource}"
+          },
+          "format": 1,
+          "rawSQL": "SELECT\n  COUNT(*) AS number_of_prod_arns\nFROM\n  \"AwsDataCatalog\".\"awsbackupobservability\".\"aws-backup-dashboards_service_metrics\"\nWHERE\n  resource_arn NOT LIKE '\"%prod%\"'\nAND substr(TRIM(\"report_time_period_end\"), 1, 10) = CAST(CURRENT_DATE AS VARCHAR);",
+          "refId": "A"
+        }
+      ],
+      "title": "Number of NON PROD Instances",
+      "transparent": true,
+      "type": "stat"
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Athena-AWS-Backup",
+          "value": "athena-grafana-aws-backup"
+        },
+        "includeAll": false,
+        "name": "datasource",
+        "options": [],
+        "query": "grafana-athena-datasource",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AWS Backup Metrics",
+  "uid": "aws_backup_metrics",
+  "version": 8
+}


### PR DESCRIPTION
The old queries weren't as flexible and would be able to query single files only.
Now it will display the data based on distinct objects and only using the latest report available, regardless of how many old ones are found.