### PR TITLE
Upgrade pipeline images and commands

### DIFF
--- a/.github/workflows/grafana-objects-deploy.yaml
+++ b/.github/workflows/grafana-objects-deploy.yaml
@@ -25,7 +25,7 @@ defaults:
 
 env:
   TF_IN_AUTOMATION: "true"
-  TERRAGRUNT_TFPATH: /usr/local/bin/tofu
+  TG_TF_PATH: /usr/local/bin/tofu
 
 jobs:
   deploy-to-grafana-cloud:
@@ -38,7 +38,7 @@ jobs:
             slack_alert_webhook: GRAFANA_CLOUD_SLACK_WEBHOOK
     runs-on: ubuntu-latest
     container:
-      image: dfdsdk/prime-pipeline:2.1.2
+      image: dfdsdk/prime-pipeline:2.2.0
     steps:
       - name: Checkout source code
         uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
           TF_VAR_synthetic_basic_auth: '{"atlantis_auth": {"username": "${{ secrets.PROD_ATLANTIS_USERNAME }}", "password": "${{ secrets.PROD_ATLANTIS_PASSWORD }}" }}'
           TF_VAR_notification_slack_webhook_url: ${{ secrets[matrix.slack_alert_webhook] }}
           TF_VAR_infinity_bearer_token: ${{ secrets.GRAFANA_CLOUD_INFINITY_DATASOURCE_GITHUB }}
-        run: terragrunt run-all apply --terragrunt-working-dir ./environments/${{ matrix.environment }} --terragrunt-source-update --terragrunt-non-interactive -input=false -auto-approve
+        run: terragrunt apply --all --working-dir ./environments/${{ matrix.environment }} --source-update --non-interactive -input=false -auto-approve
 
       - name: Send alert if job fails
         if: failure()

--- a/atlantis.yaml
+++ b/atlantis.yaml
@@ -17,7 +17,7 @@ workflows:
             name: TF_IN_AUTOMATION
             value: "true"
         - env:
-            name: TERRAGRUNT_TFPATH
+            name: TG_TF_PATH
             value: /usr/local/bin/tofu
         - env:
             name: AWS_ACCESS_KEY_ID
@@ -26,5 +26,5 @@ workflows:
             name: AWS_SECRET_ACCESS_KEY
             command: "echo $PRODUCTION_AWS_SECRET_ACCESS_KEY"
         - run: terragrunt init -upgrade
-        - run: terragrunt plan -no-color --terragrunt-non-interactive -input=false -out=$PLANFILE --terragrunt-source-update
+        - run: terragrunt plan -no-color --non-interactive -input=false -out=$PLANFILE --source-update
         - run: terragrunt show -json $PLANFILE > $SHOWFILE


### PR DESCRIPTION
## Describe your changes

This pull request updates the Terraform and Terragrunt configurations in the `.github/workflows/grafana-objects-deploy.yaml` and `atlantis.yaml` files to improve compatibility and simplify commands. Key changes include renaming environment variables, updating container images, and modifying Terragrunt commands.

### Updates to environment variables:
* Renamed the environment variable `TERRAGRUNT_TFPATH` to `TG_TF_PATH` for consistency across workflows in both `.github/workflows/grafana-objects-deploy.yaml` and `atlantis.yaml`. [[1]](diffhunk://#diff-b3179e430564fe11707dbf1bec0fd2a5952afe91e91d834561663e32d49efd6bL28-R28) [[2]](diffhunk://#diff-1dde58289359cca9a1c4a4444873f29186768ed40afbc8acb488cd01936a9fd4L20-R20)

### Updates to container images:
* Updated the Docker image for the deployment job in `.github/workflows/grafana-objects-deploy.yaml` from `dfdsdk/prime-pipeline:2.1.2` to `dfdsdk/prime-pipeline:2.2.0` to use the latest version.

### Simplification of Terragrunt commands:
* Replaced `terragrunt run-all apply` with `terragrunt apply --all` in `.github/workflows/grafana-objects-deploy.yaml` for better clarity and alignment with Terragrunt's latest syntax.
* Simplified the `terragrunt plan` command in `atlantis.yaml` by removing redundant flags and aligning with updated syntax (`--non-interactive` instead of `--terragrunt-non-interactive`).

## Checklist before requesting a review
- [x] I have rebased or merged in the latest from the default branch.
- [x] I have tested changes locally in a Docker image.
