### PR TITLE
Update error message when posting to Slack

### DIFF
--- a/.github/workflows/grafana-objects-deploy.yaml
+++ b/.github/workflows/grafana-objects-deploy.yaml
@@ -62,4 +62,4 @@ jobs:
         uses: dfds/shared-workflows/.github/actions/automation-slack-notifier@master
         with:
           slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
-          slack_message: "Configure Grafana Cloud environment failed."
+          slack_message: "Configure Grafana Cloud objects failed."


### PR DESCRIPTION
This pull request includes a minor update to the Slack notification message in the `.github/workflows/grafana-objects-deploy.yaml` file. The change updates the wording to better reflect the context of the failure.

* [`.github/workflows/grafana-objects-deploy.yaml`](diffhunk://#diff-b3179e430564fe11707dbf1bec0fd2a5952afe91e91d834561663e32d49efd6bL65-R65): Updated the `slack_message` to "Configure Grafana Cloud objects failed" for improved clarity.